### PR TITLE
chore: adding override path env var to make local devving faster []

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 BUNDLE_ANALYZE=false
 ENVIRONMENT_NAME=local
 
+# Path to override the @contentful-live/preview package for local development
+LOCAL_LIVE_PREVIEW_PACKAGE_OVERRIDE=
+
 # Your current space ID: https://www.contentful.com/help/find-space-id/
 NEXT_PUBLIC_CONFIG_CONTENTFUL_SPACE_ID=
 

--- a/config/overridePaths.js
+++ b/config/overridePaths.js
@@ -1,0 +1,18 @@
+const path = require('path');
+
+const warnAboutOverridingPackage = function (overridePath) {
+  if (warnAboutOverridingPackage.done) return;
+  console.warn(
+    '\x1b[33m%s\x1b[0m',
+    `\n[package-overrides] You are overriding the @contentful/live-preview package with ${overridePath}. To stop this remove LOCAL_LIVE_PREVIEW_PACKAGE_OVERRIDE from your .env file\n`,
+  );
+  warnAboutOverridingPackage.done = true;
+};
+
+module.exports = function overridePaths(config) {
+  if (process.env.LOCAL_LIVE_PREVIEW_PACKAGE_OVERRIDE) {
+    const overridePath = path.resolve(process.env.LOCAL_LIVE_PREVIEW_PACKAGE_OVERRIDE);
+    warnAboutOverridingPackage(overridePath);
+    config.resolve.alias['@contentful/live-preview'] = [overridePath];
+  }
+};

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const nextComposePlugins = require('next-compose-plugins');
 
 const headers = require('./config/headers');
 const includePolyfills = require('./config/includePolyfills');
+const overridePaths = require('./config/overridePaths');
 const plugins = require('./config/plugins');
 const { i18n } = require('./next-i18next.config.js');
 
@@ -84,6 +85,7 @@ module.exports = withPlugins(plugins, {
     });
 
     includePolyfills(config);
+    overridePaths(config);
 
     return config;
   },


### PR DESCRIPTION
## Purpose of PR

Adding live preview local path override to make local development faster 🏃🏻

- Add the path to where your local `live-preview` repo lives to the `LOCAL_LIVE_PREVIEW_PACKAGE_OVERRIDE` .env variable
- Run a watch on the live preview server 

![Screenshot 2023-03-22 at 15 57 45](https://user-images.githubusercontent.com/109096340/226964417-de8ed59e-ee65-40fe-82e6-2c1c25942d7d.png)

Will also show a warning in the console if you are overriding

